### PR TITLE
fix callbacks issue from connection verification

### DIFF
--- a/lib/acts_as_archive/base/table.rb
+++ b/lib/acts_as_archive/base/table.rb
@@ -7,9 +7,9 @@ module ActsAsArchive
           base.send :extend, ClassMethods
           base.send :include, InstanceMethods
 
-          if base.connection.class.to_s.include?('Mysql')
+          if base.connection_config[:adapter] == 'mysql'
             base.send :extend, ActsAsArchive::Base::Adapters::MySQL
-          elsif base.connection.class.to_s.include?('PostgreSQL')
+          elsif base.connection_config[:adapter] == 'postgresql'
             base.send :extend, ActsAsArchive::Base::Adapters::PostgreSQL
           else
             raise 'acts_as_archive does not support this database adapter'


### PR DESCRIPTION
compared against the current used branch, allows rails console to start. the verification check inside of `base.connection` is happening too early in the boot process and throwing errors on the postgresql adapter 